### PR TITLE
Fixed controller read port

### DIFF
--- a/verilog/mvutop.v
+++ b/verilog/mvutop.v
@@ -298,9 +298,7 @@ assign rdi_addr         = 0;
 //assign wri_grnt         = 0;
 assign wri_addr         = 0;
 
-
-// TODO: WIRE THESE UP TO THE AGU. PULLED UP/DOWN FOR NOW
-assign rdd_en           = {NMVU{1'b1}};                     // Always reading for now
+assign rdd_en           = run;                              // MVU reads when running
 
 // TODO: WIRE THESE UP TO SOMETHING USEFUL
 assign outload          = 0;


### PR DESCRIPTION
Controller (external) can now read on the `rdc` port of `mvutop`. Removing a static assignment to the `rdd_en` port fixed the problem. Now, the MVU only reads from data memory when it's actively running a job.

Also added a short testbench for `mvutop` to exercise the controller read port.