### PR TITLE
Fixed fusesoc builds with Xilinx BRAM IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@
 *.rlx
 *.Xil
 *.wcfg
+ip/build
 #
 .vscode/tasks.json
 
@@ -93,3 +94,6 @@
 verification/ip/xilinx/
 conv2d_jumps
 .vscode/launch.json
+
+# Fusesoc
+fusesoc.conf

--- a/mvu.core
+++ b/mvu.core
@@ -37,10 +37,6 @@ filesets:
                 file_type: systemVerilogSource
             - verification/lib/mvu/mvu_inf.svh:
                 is_include_file: true
-            - ip/build/ip/xilinx/bram64k_64x1024_xilinx/simulation/blk_mem_gen_v8_4.v
-            - ip/build/ip/xilinx/bram64k_64x1024_xilinx/sim/bram64k_64x1024_xilinx.v
-            - ip/build/ip/xilinx/bram2m_xilinx/simulation/blk_mem_gen_v8_4.v
-            - ip/build/ip/xilinx/bram2m_xilinx/sim/bram2m_xilinx.v
             - verilog/bram64k.v
             - verilog/bank64k.v
             - verilog/bram2m.v
@@ -65,6 +61,13 @@ filesets:
                 file_type: systemVerilogSource
             - verilog/mvutop.sv:
                 file_type: systemVerilogSource
+    synth_xilinx:
+        file_type: xci
+        files:
+            - ip/build/xilinx/bram2m_xilinx/bram2m_xilinx.xci
+            - ip/build/xilinx/bram64k_64x1024_xilinx/bram64k_64x1024_xilinx.xci
+            - mvu.xdc:
+                file_type: xdc
     tb:
         file_type: systemVerilogSource
         files:
@@ -80,13 +83,13 @@ filesets:
             - verification/tests/gemv/gemv_tester.sv:
                 is_include_file: true
             - verification/lib/testbench/testbench_top.sv
-            - ip/build/ip/xilinx/bram64k_64x1024_xilinx/simulation/blk_mem_gen_v8_4.v:
+            - ip/build/xilinx/bram64k_64x1024_xilinx/simulation/blk_mem_gen_v8_4.v:
                 file_type: verilogSource
-            - ip/build/ip/xilinx/bram64k_64x1024_xilinx/sim/bram64k_64x1024_xilinx.v:
+            - ip/build/xilinx/bram64k_64x1024_xilinx/sim/bram64k_64x1024_xilinx.v:
                 file_type: verilogSource
-            - ip/build/ip/xilinx/bram2m_xilinx/simulation/blk_mem_gen_v8_4.v:
+            - ip/build/xilinx/bram2m_xilinx/simulation/blk_mem_gen_v8_4.v:
                 file_type: verilogSource
-            - ip/build/ip/xilinx/bram2m_xilinx/sim/bram2m_xilinx.v:
+            - ip/build/xilinx/bram2m_xilinx/sim/bram2m_xilinx.v:
                 file_type: verilogSource
 targets:
     sim:
@@ -104,10 +107,12 @@ targets:
         description: Synthesize the design for an FPGA board
         filesets:
             - synth
+            - synth_xilinx
         default_tool: vivado
         tools:
           vivado:
             part: xcku115-flva1517-2-e
+            pnr: none
         parameters: [XILINX]
         toplevel: [mvutop]
 parameters:

--- a/mvu.xdc
+++ b/mvu.xdc
@@ -1,0 +1,1 @@
+create_clock -period 4.000 -name clk -waveform {0.000 2.000} [get_ports {intf\\.clk}]

--- a/tclscripts/gen_xilinx_ip.tcl
+++ b/tclscripts/gen_xilinx_ip.tcl
@@ -5,7 +5,7 @@ source common.tcl
 
 # Set some directories
 set xcisrcpath ../ip/xilinx
-set buildpath ../ip/build/ip/xilinx
+set buildpath ../ip/build/xilinx
 set verifyippath ../verification/ip/xilinx
 file mkdir $buildpath
 


### PR DESCRIPTION
Fixes problems with synthesis when using `fusesoc` and Xilinx Vivado.

- `.xci` files for BRAM IPs are now listed in the `fusesoc` core file. `fusesoc` will automatically generate the Vivado tcl scripts to import and synthesize the IP components.
- `.xci` files need to be synced to the version of Vivado being used. Originally generated by v2019.2. User is required to run the `tclscripts/gen_xilinx_ip.tcl` script in Vivado prior to `fusesoc`.
- Added timing constraints file and included in `fusesoc` core file.
- Updated README with instructions.