### PR TITLE
GEMV Testbench fix

### DIFF
--- a/tclscripts/common.tcl
+++ b/tclscripts/common.tcl
@@ -2,7 +2,7 @@
 # Common variables for tcl build scripts
 #
 
-set xilinxpart xcku115-flva1517-2-e
+set xilinxpart xcvu9p-flgb2104-2-e
 
 #
 # Init commands

--- a/verification/ip/xilinx/bram2m_xilinx.v
+++ b/verification/ip/xilinx/bram2m_xilinx.v
@@ -1,4 +1,4 @@
-// (c) Copyright 1995-2021 Xilinx, Inc. All rights reserved.
+// (c) Copyright 1995-2022 Xilinx, Inc. All rights reserved.
 // 
 // This file contains confidential and proprietary information
 // of Xilinx, Inc. and is protected under U.S. and
@@ -48,7 +48,7 @@
 
 
 // IP VLNV: xilinx.com:ip:blk_mem_gen:8.4
-// IP Revision: 3
+// IP Revision: 4
 
 `timescale 1ns/1ps
 
@@ -86,9 +86,9 @@ input wire [8 : 0] addrb;
 (* X_INTERFACE_INFO = "xilinx.com:interface:bram:1.0 BRAM_PORTB DOUT" *)
 output wire [4095 : 0] doutb;
 
-  blk_mem_gen_v8_4_3 #(
-    .C_FAMILY("kintexu"),
-    .C_XDEVICEFAMILY("kintexu"),
+  blk_mem_gen_v8_4_4 #(
+    .C_FAMILY("virtexuplus"),
+    .C_XDEVICEFAMILY("virtexuplus"),
     .C_ELABORATION_DIR("./"),
     .C_INTERFACE_TYPE(0),
     .C_AXI_TYPE(1),
@@ -161,7 +161,7 @@ output wire [4095 : 0] doutb;
     .C_DISABLE_WARN_BHV_RANGE(0),
     .C_COUNT_36K_BRAM("57"),
     .C_COUNT_18K_BRAM("0"),
-    .C_EST_POWER_SUMMARY("Estimated Power for IP     :     277.382912 mW")
+    .C_EST_POWER_SUMMARY("Estimated Power for IP     :     148.935104 mW")
   ) inst (
     .clka(clka),
     .rsta(1'D0),

--- a/verification/lib/testbench/testbench_base.sv
+++ b/verification/lib/testbench/testbench_base.sv
@@ -472,7 +472,7 @@ class mvu_testbench_base extends BaseObj;
         apb_addr = apb_addr_t'({3'(mvu), mvu_pkg::CSR_MVUCOMMAND});
         fork
             apb_master.write(apb_addr, apb_data, apb_strb, apb_resp);
-            wait_for_irq(omvu);
+            wait_for_irq(mvu);
         join
     endtask
 // =================================================================================================

--- a/verification/lib/testbench/testbench_base.sv
+++ b/verification/lib/testbench/testbench_base.sv
@@ -83,6 +83,14 @@ class mvu_testbench_base extends BaseObj;
         mvu_ext_if.wrc_addr = addr;
         mvu_ext_if.wrc_word = word;
         mvu_ext_if.wrc_en[mvu] = 1'b1;
+        while (1) begin
+            @(posedge mvu_ext_if.clk);
+            if (mvu_ext_if.wrc_grnt[mvu] == 1) begin
+                break;
+            end else begin
+                logger.print($sformatf("writeData: did not get grant signal for MVU %0d for address %x, so waiting until next cycle.", mvu, addr));
+            end
+        end
         @(posedge mvu_ext_if.clk)
         mvu_ext_if.wrc_en[mvu] = 1'b0;
     endtask

--- a/verification/tests/gemv/gemv_tester.sv
+++ b/verification/tests/gemv/gemv_tester.sv
@@ -15,13 +15,13 @@ class gemv_tester extends mvu_testbench_base;
 
         logger.print("TEST gemv 1: matrix-vector mult: 1x1 x 1 tiles, 1x1 => 1 bit precision, , input=all 0's");
         runGEMV(.mvu(mvu), .iprec(1), .wprec(1), .oprec(1), 
-                .omsb(0), .iaddr(0), .waddr(0), .saddr(0), .baddr(0), .omvu(omvu), .obank(0), .oaddr(0), 
+                .omsb(0), .iaddr(0), .waddr(0), .saddr(0), .baddr(0), .omvu(omvu), .obank(1), .oaddr(0), 
                 .m_w(1), .m_h(1), .scaler(scaler));
 
 
         logger.print("TEST gemv 2: matrix-vector mult: 2x2 x 2 tiles, 1x1 => 1 bit precision, input=all 0's");
         runGEMV(.mvu(mvu), .iprec(1), .wprec(1), .oprec(1), 
-                .omsb(0), .iaddr(0), .waddr(0), .saddr(0), .baddr(0), .omvu(omvu), .obank(0), .oaddr(0), 
+                .omsb(0), .iaddr(0), .waddr(0), .saddr(0), .baddr(0), .omvu(omvu), .obank(1), .oaddr(0), 
                 .m_w(2), .m_h(2), .scaler(scaler));
 
 


### PR DESCRIPTION
In `testbench_base`, was found that some writes to MVU data memories from the controller interface were not being applied since the MVUs themselves were also writing to data memories at the same. This resulted from the testbench code not explicitly checking if it had been granted access to the MVU data memory.

The fix in this PR implements code in the testbench to check for the grant signal from the controller write interface to the MVU data memory. It stalls until it receives the grant.